### PR TITLE
Add Jenkins pipeline and Docker build configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM eclipse-temurin:21-jdk AS build
+
+WORKDIR /workspace
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+COPY src src
+
+RUN chmod +x gradlew \
+    && ./gradlew bootJar --no-daemon
+RUN JAR_PATH=$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' -print -quit) \
+    && cp "$JAR_PATH" /workspace/app.jar
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=build /workspace/app.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,85 @@
+pipeline {
+    agent { label 'docker' }
+
+    environment {
+        REGISTRY_IMAGE       = 'registry.example.com/smartcane-api'
+        DOCKER_CREDENTIALS_ID = 'docker-registry-credentials'
+        DOCKERFILE_PATH      = 'Dockerfile'
+        DEPLOY_JOB           = ''
+    }
+
+    options {
+        timestamps()
+        skipDefaultCheckout(true)
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                script {
+                    env.GIT_SHORT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                }
+            }
+        }
+
+        stage('Build & Test') {
+            agent {
+                docker {
+                    image 'eclipse-temurin:21-jdk'
+                    args '-v $WORKSPACE/.gradle:/home/gradle/.gradle'
+                }
+            }
+            steps {
+                sh './gradlew clean test'
+                sh './gradlew bootJar'
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
+                    archiveArtifacts artifacts: 'build/libs/*.jar', fingerprint: true, allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Docker Build') {
+            steps {
+                script {
+                    env.IMAGE_TAG = env.GIT_SHORT_COMMIT ?: env.BUILD_NUMBER
+                }
+                sh "docker build -f ${env.DOCKERFILE_PATH} -t ${env.REGISTRY_IMAGE}:${env.IMAGE_TAG} ."
+            }
+        }
+
+        stage('Docker Push') {
+            when {
+                expression { return env.DOCKER_CREDENTIALS_ID?.trim() }
+            }
+            steps {
+                withCredentials([
+                    usernamePassword(
+                        credentialsId: env.DOCKER_CREDENTIALS_ID,
+                        usernameVariable: 'REGISTRY_USERNAME',
+                        passwordVariable: 'REGISTRY_PASSWORD'
+                    )
+                ]) {
+                    script {
+                        def registryHost = env.REGISTRY_IMAGE.split('/')[0]
+                        sh "echo ${REGISTRY_PASSWORD} | docker login ${registryHost} --username ${REGISTRY_USERNAME} --password-stdin"
+                        sh "docker push ${env.REGISTRY_IMAGE}:${env.IMAGE_TAG}"
+                        sh 'docker logout || true'
+                    }
+                }
+            }
+        }
+
+        stage('Trigger Deployment') {
+            when {
+                expression { return env.DEPLOY_JOB?.trim() }
+            }
+            steps {
+                build job: env.DEPLOY_JOB, parameters: [string(name: 'IMAGE_TAG', value: env.IMAGE_TAG)]
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a declarative Jenkins pipeline that builds and tests with JDK 21, creates and pushes tagged Docker images, archives build outputs, and optionally triggers downstream deployments
- add a multi-stage Dockerfile for building the Spring Boot jar and packaging it into a runtime image

## Testing
- ⚠️ `bash gradlew test` *(fails: Unable to tunnel through proxy while downloading Gradle wrapper dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce54a8c65c832990733630047cc073