### PR TITLE
Add API health check endpoint and update security configuration

### DIFF
--- a/src/main/java/com/smartcane/api/global/health/HealthCheckController.java
+++ b/src/main/java/com/smartcane/api/global/health/HealthCheckController.java
@@ -1,0 +1,30 @@
+package com.smartcane.api.global.health;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * 간단한 헬스 체크 컨트롤러.
+ * 운영 환경에서 인프라 모니터링을 위해 상태값과 서버 시간을 함께 반환한다.
+ */
+@RestController
+public class HealthCheckController {
+
+    /**
+     * /api/healthz 엔드포인트를 통해 서비스의 기초 상태를 확인한다.
+     * 현재는 항상 200 OK와 간단한 JSON 바디를 응답하도록 구성하였다.
+     */
+    @GetMapping("/api/healthz")
+    public ResponseEntity<Map<String, Object>> healthz() {
+        return ResponseEntity.ok(
+                Map.of(
+                        "status", "UP",               // 상태 문자열
+                        "timestamp", Instant.now().toString() // 서버 기준 타임스탬프
+                )
+        );
+    }
+}

--- a/src/main/java/com/smartcane/api/security/config/SecurityConfig.java
+++ b/src/main/java/com/smartcane/api/security/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/actuator/health",
+                                "/api/healthz",                       // 신규 헬스 체크 엔드포인트
                                 "/api/auth/**",                               // 회원가입/로그인/리프레시/로그아웃
                                 "/oauth2/**", "/login/oauth2/**", "/oauth2/authorization/**"
                         ).permitAll()


### PR DESCRIPTION
## Summary
- add a dedicated `/api/healthz` controller for basic service health checks
- expose the new health check endpoint through the existing security configuration

## Testing
- `bash gradlew test` *(fails: Gradle wrapper cannot be downloaded in the execution environment due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd960c4d88329a0f4f087c125f430