### PR TITLE
Add point domain skeleton for payments

### DIFF
--- a/src/main/java/com/smartcane/api/domain/point/entity/PointAccount.java
+++ b/src/main/java/com/smartcane/api/domain/point/entity/PointAccount.java
@@ -1,0 +1,69 @@
+package com.smartcane.api.domain.point.entity;
+
+import com.smartcane.api.common.model.Auditable;
+import com.smartcane.api.domain.identity.entity.User;
+import com.smartcane.api.domain.point.exception.PointInsufficientBalanceException;
+import jakarta.persistence.*;
+
+/**
+ * 사용자별 포인트 잔고를 관리하는 JPA 엔티티 스켈레톤입니다.
+ * 추후 정산 이력과 적립 정책을 확장할 수 있도록 최소한의 필드만 구성했습니다.
+ */
+@Entity
+@Table(name = "point_accounts")
+public class PointAccount extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;                              // 고유 식별자
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;                            // 포인트를 보유한 사용자
+
+    @Column(nullable = false)
+    private long balance = 0L;                    // 보유 포인트 잔액
+
+    protected PointAccount() {
+        // JPA 기본 생성자
+    }
+
+    public PointAccount(User user) {
+        this.user = user;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public long getBalance() {
+        return balance;
+    }
+
+    /**
+     * 포인트를 적립할 때 호출합니다.
+     */
+    public void accumulate(long amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("포인트 적립 금액은 음수일 수 없습니다.");
+        }
+        this.balance += amount;
+    }
+
+    /**
+     * 포인트를 차감할 때 호출합니다. 잔고 부족 시 전용 예외를 발생시킵니다.
+     */
+    public void deduct(long amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("포인트 차감 금액은 음수일 수 없습니다.");
+        }
+        if (balance < amount) {
+            throw new PointInsufficientBalanceException(balance, amount);
+        }
+        this.balance -= amount;
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/point/exception/PointAccountNotFoundException.java
+++ b/src/main/java/com/smartcane/api/domain/point/exception/PointAccountNotFoundException.java
@@ -1,0 +1,11 @@
+package com.smartcane.api.domain.point.exception;
+
+/**
+ * 사용자의 포인트 계정이 존재하지 않을 때 발생하는 예외입니다.
+ */
+public class PointAccountNotFoundException extends PointException {
+
+    public PointAccountNotFoundException(Long userId) {
+        super(String.format("사용자(%d)의 포인트 계정을 찾을 수 없습니다.", userId));
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/point/exception/PointException.java
+++ b/src/main/java/com/smartcane/api/domain/point/exception/PointException.java
@@ -1,0 +1,16 @@
+package com.smartcane.api.domain.point.exception;
+
+/**
+ * 포인트 도메인에서 공통적으로 사용될 사용자 정의 예외의 최상위 타입입니다.
+ * 추후 세부 예외를 확장할 수 있도록 런타임 예외를 상속받습니다.
+ */
+public class PointException extends RuntimeException {
+
+    public PointException(String message) {
+        super(message);
+    }
+
+    public PointException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/point/exception/PointInsufficientBalanceException.java
+++ b/src/main/java/com/smartcane/api/domain/point/exception/PointInsufficientBalanceException.java
@@ -1,0 +1,11 @@
+package com.smartcane.api.domain.point.exception;
+
+/**
+ * 포인트 결제 또는 차감 시 잔고가 부족한 경우 발생하는 예외입니다.
+ */
+public class PointInsufficientBalanceException extends PointException {
+
+    public PointInsufficientBalanceException(long balance, long required) {
+        super(String.format("포인트 잔고가 부족합니다. 현재 잔고: %d, 필요 포인트: %d", balance, required));
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/point/repository/PointAccountRepository.java
+++ b/src/main/java/com/smartcane/api/domain/point/repository/PointAccountRepository.java
@@ -1,0 +1,14 @@
+package com.smartcane.api.domain.point.repository;
+
+import com.smartcane.api.domain.point.entity.PointAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 포인트 계정을 조회/저장하기 위한 Spring Data JPA 리포지토리 인터페이스입니다.
+ */
+public interface PointAccountRepository extends JpaRepository<PointAccount, Long> {
+
+    Optional<PointAccount> findByUserId(Long userId);
+}

--- a/src/main/java/com/smartcane/api/domain/point/service/PointPaymentService.java
+++ b/src/main/java/com/smartcane/api/domain/point/service/PointPaymentService.java
@@ -1,0 +1,45 @@
+package com.smartcane.api.domain.point.service;
+
+import com.smartcane.api.domain.point.entity.PointAccount;
+import com.smartcane.api.domain.point.exception.PointAccountNotFoundException;
+import com.smartcane.api.domain.point.repository.PointAccountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 포인트 결제 및 적립을 담당하는 도메인 서비스의 스켈레톤입니다.
+ */
+@Service
+public class PointPaymentService {
+
+    private final PointAccountRepository pointAccountRepository;
+
+    public PointPaymentService(PointAccountRepository pointAccountRepository) {
+        this.pointAccountRepository = pointAccountRepository;
+    }
+
+    /**
+     * 주어진 사용자에 대해 포인트 결제를 처리합니다.
+     * 잔고 부족 시 {@link com.smartcane.api.domain.point.exception.PointInsufficientBalanceException}이 발생합니다.
+     */
+    @Transactional
+    public long payWithPoint(Long userId, long amount) {
+        PointAccount account = pointAccountRepository.findByUserId(userId)
+                .orElseThrow(() -> new PointAccountNotFoundException(userId));
+
+        account.deduct(amount);  // 실제 차감 로직은 엔티티가 담당합니다.
+        return account.getBalance();
+    }
+
+    /**
+     * 외부 결제 성공 등의 이벤트에 맞춰 포인트를 적립할 때 사용할 수 있습니다.
+     */
+    @Transactional
+    public long accumulatePoint(Long userId, long amount) {
+        PointAccount account = pointAccountRepository.findByUserId(userId)
+                .orElseThrow(() -> new PointAccountNotFoundException(userId));
+
+        account.accumulate(amount);  // 적립 로직 역시 엔티티로 위임했습니다.
+        return account.getBalance();
+    }
+}


### PR DESCRIPTION
## Summary
- add a PointAccount JPA entity with accumulate/deduct helpers
- introduce point-specific exceptions for missing accounts and insufficient balance
- provide a PointPaymentService and repository skeleton for future point payment flows

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68f4a8b806388329879ae61a4bc79854