### PR TITLE
Add point controller endpoints for balance lookup and charging

### DIFF
--- a/src/main/java/com/smartcane/api/domain/point/controller/PointController.java
+++ b/src/main/java/com/smartcane/api/domain/point/controller/PointController.java
@@ -1,0 +1,42 @@
+package com.smartcane.api.domain.point.controller;
+
+import com.smartcane.api.domain.point.dto.PointBalanceResponse;
+import com.smartcane.api.domain.point.dto.PointChargeRequest;
+import com.smartcane.api.domain.point.service.PointPaymentService;
+import com.smartcane.api.security.util.AuthUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 포인트 잔액 조회 및 충전 기능을 노출하는 프레젠테이션 레이어입니다.
+ */
+@RestController
+@RequestMapping("/api/points")
+@RequiredArgsConstructor
+public class PointController {
+
+    private final PointPaymentService pointPaymentService;
+
+    @GetMapping("/me")
+    public PointBalanceResponse getMyBalance() {
+        // SecurityContext에 저장된 현재 로그인 사용자의 ID를 가져옵니다.
+        Long userId = AuthUtil.currentUserId();
+        long balance = pointPaymentService.getPointBalance(userId);
+        // 프론트엔드에서 금액만 필요하므로 단순한 응답 DTO로 감싸서 반환합니다.
+        return new PointBalanceResponse(balance);
+    }
+
+    @PostMapping("/charge")
+    public PointBalanceResponse chargePoint(@Valid @RequestBody PointChargeRequest request) {
+        // 로그인 사용자 기준으로만 충전이 가능하도록 서버에서 사용자 ID를 강제합니다.
+        Long userId = AuthUtil.currentUserId();
+        long balance = pointPaymentService.chargePoint(userId, request.amount());
+        // 충전 이후 갱신된 잔액을 바로 응답하여 포인트 탭에 표시할 수 있게 합니다.
+        return new PointBalanceResponse(balance);
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/point/dto/PointBalanceResponse.java
+++ b/src/main/java/com/smartcane/api/domain/point/dto/PointBalanceResponse.java
@@ -1,0 +1,7 @@
+package com.smartcane.api.domain.point.dto;
+
+/**
+ * 현재 포인트 잔액을 프론트엔드에 전달하기 위한 응답 전용 DTO 입니다.
+ */
+public record PointBalanceResponse(long balance) {
+}

--- a/src/main/java/com/smartcane/api/domain/point/dto/PointChargeRequest.java
+++ b/src/main/java/com/smartcane/api/domain/point/dto/PointChargeRequest.java
@@ -1,0 +1,9 @@
+package com.smartcane.api.domain.point.dto;
+
+import jakarta.validation.constraints.Positive;
+
+/**
+ * 포인트 충전 금액을 전달 받기 위한 요청 DTO 입니다.
+ */
+public record PointChargeRequest(@Positive(message = "충전 금액은 0보다 커야 합니다.") long amount) {
+}

--- a/src/main/java/com/smartcane/api/domain/point/service/PointPaymentService.java
+++ b/src/main/java/com/smartcane/api/domain/point/service/PointPaymentService.java
@@ -39,6 +39,14 @@ public class PointPaymentService {
     }
 
     /**
+     * 읽기 전용 트랜잭션에서 사용할 포인트 계정을 조회합니다.
+     */
+    private PointAccount getAccount(Long userId) {
+        return pointAccountRepository.findByUserId(userId)
+                .orElseThrow(() -> new PointAccountNotFoundException(userId));
+    }
+
+    /**
      * 주어진 사용자에 대해 포인트 결제를 처리합니다.
      * 잔고 부족 시 {@link com.smartcane.api.domain.point.exception.PointInsufficientBalanceException}이 발생합니다.
      */
@@ -69,5 +77,11 @@ public class PointPaymentService {
     @Transactional
     public long chargePoint(Long userId, long amount) {
         return accumulatePoint(userId, amount);
+    }
+
+    @Transactional(readOnly = true)
+    public long getPointBalance(Long userId) {
+        // 조회 시에는 별도 갱신이 없으므로 읽기 전용 트랜잭션으로 처리합니다.
+        return getAccount(userId).getBalance();
     }
 }


### PR DESCRIPTION
## Summary
- expose point APIs for the authenticated user to check the current balance and request point charges
- add request/response DTOs dedicated to the frontend point tab
- extend the point payment service with a read-only balance lookup helper

## Testing
- sh gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68f75afb3af4832994689f561a6d4886