### PR TITLE
Add admin domain skeleton for user and device management

### DIFF
--- a/src/main/java/com/smartcane/api/domain/admin/controller/AdminDeviceController.java
+++ b/src/main/java/com/smartcane/api/domain/admin/controller/AdminDeviceController.java
@@ -1,0 +1,55 @@
+package com.smartcane.api.domain.admin.controller;
+
+import com.smartcane.api.domain.admin.dto.AdminDeviceDetailResponse;
+import com.smartcane.api.domain.admin.dto.AdminDeviceSummaryResponse;
+import com.smartcane.api.domain.admin.dto.DeviceAssignmentRequest;
+import com.smartcane.api.domain.admin.service.AdminDeviceService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 디바이스 관리 엔드포인트 스켈레톤.
+ */
+@RestController
+@RequestMapping("/api/admin/devices")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminDeviceController {
+
+    private final AdminDeviceService adminDeviceService;
+
+    @GetMapping
+    public List<AdminDeviceSummaryResponse> listDevices() {
+        // TODO: 필터 조건(상태, 등록일 등)을 받아서 처리하도록 확장
+        return adminDeviceService.listDevices();
+    }
+
+    @GetMapping("/{deviceId}")
+    public AdminDeviceDetailResponse getDevice(@PathVariable UUID deviceId) {
+        // TODO: 존재하지 않는 경우 예외 처리 추가
+        return adminDeviceService.getDevice(deviceId);
+    }
+
+    @PostMapping("/{deviceId}/assign")
+    public void assignDevice(@PathVariable UUID deviceId,
+                             @Valid @RequestBody DeviceAssignmentRequest request) {
+        // TODO: 디바이스 사용 이력 저장 등의 부가 로직 고려
+        adminDeviceService.assignDevice(deviceId, request);
+    }
+
+    @DeleteMapping("/{deviceId}/assign")
+    public void releaseDevice(@PathVariable UUID deviceId) {
+        // TODO: 해제 이벤트 발행 등 추가 요구사항을 구현
+        adminDeviceService.releaseDevice(deviceId);
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/admin/controller/AdminUserController.java
+++ b/src/main/java/com/smartcane/api/domain/admin/controller/AdminUserController.java
@@ -1,0 +1,48 @@
+package com.smartcane.api.domain.admin.controller;
+
+import com.smartcane.api.domain.admin.dto.AdminUserDetailResponse;
+import com.smartcane.api.domain.admin.dto.AdminUserSummaryResponse;
+import com.smartcane.api.domain.admin.dto.AdminUserUpdateRequest;
+import com.smartcane.api.domain.admin.service.AdminUserService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 회원 관리 엔드포인트 스켈레톤.
+ * 모든 요청은 /api/admin/users 로 진입하며, ADMIN 권한 사용자만 접근할 수 있도록 구성한다.
+ */
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping
+    public List<AdminUserSummaryResponse> listUsers() {
+        // TODO: 페이징/검색 파라미터 확장을 고려하여 구현
+        return adminUserService.listUsers();
+    }
+
+    @GetMapping("/{userId}")
+    public AdminUserDetailResponse getUser(@PathVariable Long userId) {
+        // TODO: 에러 핸들링 정책(404 등) 적용
+        return adminUserService.getUser(userId);
+    }
+
+    @PatchMapping("/{userId}")
+    public AdminUserDetailResponse updateUser(@PathVariable Long userId,
+                                              @Valid @RequestBody AdminUserUpdateRequest request) {
+        // TODO: 감사 로그 등 보안 관련 처리를 추가할 수 있음
+        return adminUserService.updateUser(userId, request);
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/AdminDeviceDetailResponse.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/AdminDeviceDetailResponse.java
@@ -1,0 +1,18 @@
+package com.smartcane.api.domain.admin.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 관리자 디바이스 상세 응답 스켈레톤.
+ */
+public record AdminDeviceDetailResponse(
+        UUID id,
+        String serialNo,
+        String displayName,
+        AdminDeviceSummaryResponse.DeviceStatus status,
+        Instant createdAt,
+        Instant updatedAt,
+        Long ownerId
+) {
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/AdminDeviceSummaryResponse.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/AdminDeviceSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.smartcane.api.domain.admin.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 관리자 디바이스 목록 응답 스켈레톤.
+ */
+public record AdminDeviceSummaryResponse(
+        UUID id,
+        String serialNo,
+        String displayName,
+        DeviceStatus status,
+        Instant createdAt
+) {
+    /**
+     * 관리자 기능에서 사용할 디바이스 상태 표현용 내부 enum.
+     * 실제 구현 시 Device 엔티티의 상태 정책과 동기화해야 한다.
+     */
+    public enum DeviceStatus {
+        ACTIVE,
+        SUSPENDED,
+        RETIRED
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserDetailResponse.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserDetailResponse.java
@@ -1,0 +1,20 @@
+package com.smartcane.api.domain.admin.dto;
+
+import com.smartcane.api.domain.identity.entity.User;
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * 관리자 화면에서 단일 사용자 상세 정보를 내려줄 때 사용할 DTO 스켈레톤.
+ */
+public record AdminUserDetailResponse(
+        Long id,
+        String email,
+        String nickname,
+        LocalDate birthDate,
+        User.Role role,
+        User.Status status,
+        Instant createdAt,
+        Instant lastLoginAt
+) {
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserSummaryResponse.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.smartcane.api.domain.admin.dto;
+
+import com.smartcane.api.domain.identity.entity.User;
+import java.time.Instant;
+
+/**
+ * 관리자 전용 사용자 목록 응답 스켈레톤.
+ * 실제 구현 시 User 엔티티를 변환하도록 교체하면 된다.
+ */
+public record AdminUserSummaryResponse(
+        Long id,
+        String email,
+        String nickname,
+        User.Role role,
+        User.Status status,
+        Instant createdAt
+) {
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserUpdateRequest.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/AdminUserUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.smartcane.api.domain.admin.dto;
+
+import com.smartcane.api.domain.identity.entity.User;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 관리자 전용 사용자 정보 수정 요청 스켈레톤.
+ */
+public record AdminUserUpdateRequest(
+        @NotNull(message = "변경할 권한은 필수입니다.") User.Role role,
+        @NotNull(message = "변경할 상태는 필수입니다.") User.Status status
+) {
+}

--- a/src/main/java/com/smartcane/api/domain/admin/dto/DeviceAssignmentRequest.java
+++ b/src/main/java/com/smartcane/api/domain/admin/dto/DeviceAssignmentRequest.java
@@ -1,0 +1,11 @@
+package com.smartcane.api.domain.admin.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 관리자 디바이스 소유자 지정/변경 요청 스켈레톤.
+ */
+public record DeviceAssignmentRequest(
+        @NotNull(message = "연결할 회원 ID는 필수입니다.") Long userId
+) {
+}

--- a/src/main/java/com/smartcane/api/domain/admin/service/AdminDeviceService.java
+++ b/src/main/java/com/smartcane/api/domain/admin/service/AdminDeviceService.java
@@ -1,0 +1,39 @@
+package com.smartcane.api.domain.admin.service;
+
+import com.smartcane.api.domain.admin.dto.AdminDeviceDetailResponse;
+import com.smartcane.api.domain.admin.dto.AdminDeviceSummaryResponse;
+import com.smartcane.api.domain.admin.dto.DeviceAssignmentRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 관리자 디바이스 관리 기능 스켈레톤 서비스.
+ */
+@Slf4j
+@Service
+public class AdminDeviceService {
+
+    public List<AdminDeviceSummaryResponse> listDevices() {
+        // TODO: 디바이스 목록 조회 (필터링, 정렬 등)
+        log.debug("[ADMIN] 디바이스 목록 조회 스켈레톤 호출");
+        return Collections.emptyList();
+    }
+
+    public AdminDeviceDetailResponse getDevice(UUID deviceId) {
+        // TODO: 단일 디바이스 상세 조회 로직 구현
+        throw new UnsupportedOperationException("관리자 디바이스 상세 조회 로직이 아직 구현되지 않았습니다. deviceId=" + deviceId);
+    }
+
+    public void assignDevice(UUID deviceId, DeviceAssignmentRequest request) {
+        // TODO: 특정 사용자에게 디바이스 할당 로직 구현
+        throw new UnsupportedOperationException("디바이스 소유자 지정 로직이 아직 구현되지 않았습니다. deviceId=" + deviceId);
+    }
+
+    public void releaseDevice(UUID deviceId) {
+        // TODO: 디바이스 소유자 해제 로직 구현
+        throw new UnsupportedOperationException("디바이스 소유자 해제 로직이 아직 구현되지 않았습니다. deviceId=" + deviceId);
+    }
+}

--- a/src/main/java/com/smartcane/api/domain/admin/service/AdminUserService.java
+++ b/src/main/java/com/smartcane/api/domain/admin/service/AdminUserService.java
@@ -1,0 +1,34 @@
+package com.smartcane.api.domain.admin.service;
+
+import com.smartcane.api.domain.admin.dto.AdminUserDetailResponse;
+import com.smartcane.api.domain.admin.dto.AdminUserSummaryResponse;
+import com.smartcane.api.domain.admin.dto.AdminUserUpdateRequest;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 관리자 회원 관리 기능 스켈레톤 서비스.
+ * 실제 구현 시 repository, mapper 등을 주입받아 비즈니스 로직을 완성하면 된다.
+ */
+@Slf4j
+@Service
+public class AdminUserService {
+
+    public List<AdminUserSummaryResponse> listUsers() {
+        // TODO: 관리자 회원 조회 로직 구현 (페이징, 검색 등 확장 가능)
+        log.debug("[ADMIN] 사용자 목록 조회 스켈레톤 호출");
+        return Collections.emptyList();
+    }
+
+    public AdminUserDetailResponse getUser(Long userId) {
+        // TODO: 단일 사용자 상세 조회 로직 구현
+        throw new UnsupportedOperationException("관리자 사용자 상세 조회 로직이 아직 구현되지 않았습니다. userId=" + userId);
+    }
+
+    public AdminUserDetailResponse updateUser(Long userId, AdminUserUpdateRequest request) {
+        // TODO: 권한/상태 변경 등 사용자 수정 로직 구현
+        throw new UnsupportedOperationException("관리자 사용자 수정 로직이 아직 구현되지 않았습니다. userId=" + userId);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin user management controller, DTOs, and service skeleton secured under /api/admin/users
- add admin device management controller, DTOs, and service skeleton secured under /api/admin/devices
- scaffold request/response records with validation hints and TODO comments for future implementation

## Testing
- ./gradlew test *(fails: unable to download dependencies due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6907773879308329afd9e4113638eace